### PR TITLE
Fix authentication errors for passwords with special characters

### DIFF
--- a/tap_clickhouse/client.py
+++ b/tap_clickhouse/client.py
@@ -6,6 +6,7 @@ This includes ClickHouseStream and ClickHouseConnector.
 from __future__ import annotations
 
 from typing import Any, Iterable
+from urllib.parse import quote
 
 import sqlalchemy  # noqa: TCH002
 from singer_sdk import SQLConnector, SQLStream
@@ -37,7 +38,7 @@ class ClickHouseConnector(SQLConnector):
         else:
             secure_options = f"secure={config['secure']}&verify={config['verify']}"
         return (
-            f"clickhouse+{config['driver']}://{config['username']}:{config['password']}@"
+            f"clickhouse+{config['driver']}://{quote(config['username'])}:{quote(config['password'])}@"
             f"{config['host']}:{config['port']}/"
             f"{config['database']}?{secure_options}"
         )


### PR DESCRIPTION
Passwords containing special characters such as < need to be urlescaped. This patch applies url quoting for username and password configuration parameters.

related issue / pr: https://github.com/shaped-ai/target-clickhouse/pull/227